### PR TITLE
Fix SyntaxError with Python 3.8 in cli.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 
 sourceline: "ppa:ubuntu-toolchain-r/test"
 

--- a/sem/cli.py
+++ b/sem/cli.py
@@ -282,7 +282,7 @@ def export(results_dir, filename, do_not_try_parsing, parameters):
                 required=True)
 @click.argument('sources',
                 nargs=-1,
-                (type)=click.Path(exists=True, resolve_path=True),
+                type=click.Path(exists=True, resolve_path=True),
                 required=True)
 @click.option("--move",
               default=False,


### PR DESCRIPTION
Running with Python 3.8 causes this syntax error:
```python
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/.../sem/sem/__init__.py", line 8, in <module>
    from .cli import cli
  File "/.../sem/sem/cli.py", line 285
    (type)=click.Path(exists=True, resolve_path=True),
    ^
SyntaxError: expression cannot contain assignment, perhaps you meant "=="?
```

Some language syntax probably changed in more recent Python versions (I'm not sure if this only happens with 3.8). I saw this has already been fixed in the `develop` branch, but maybe this PR can be merged in `master` to fix this there temporarily without bringing in all the `develop` changes?
