### PR TITLE
Use python3 instead of python

### DIFF
--- a/sem/gridrunner.py
+++ b/sem/gridrunner.py
@@ -122,12 +122,12 @@ class GridRunner(SimulationRunner):
 
         clean_before = False
         if clean_before:
-            clean_command = 'python waf distclean'
+            clean_command = 'python3 waf distclean'
             self.run_program((clean_command), self.path,
                              native_spec=BUILD_GRID_PARAMS)
 
         if not skip_configuration:
-            configuration_command = 'python waf configure --enable-examples ' +\
+            configuration_command = 'python3 waf configure --enable-examples ' +\
                 '--disable-gtk --disable-python '
             if optimized:
                 configuration_command += '--build-profile=optimized ' +\
@@ -135,7 +135,7 @@ class GridRunner(SimulationRunner):
             self.run_program((configuration_command), self.path,
                              native_spec=BUILD_GRID_PARAMS)
 
-        self.run_program(('python waf build'), self.path,
+        self.run_program(('python3 waf build'), self.path,
                          native_spec=BUILD_GRID_PARAMS)
 
     def get_available_parameters(self):

--- a/sem/runner.py
+++ b/sem/runner.py
@@ -129,9 +129,8 @@ class SimulationRunner(object):
 
         # Only configure if necessary
         if not skip_configuration:
-            configuration_command = ['python', 'waf', 'configure',
-                                     '--enable-examples', '--disable-gtk',
-                                     '--disable-python']
+            configuration_command = ['python3', 'waf', 'configure', '--enable-examples',
+                                     '--disable-gtk', '--disable-python']
 
             if optimized:
                 configuration_command += ['--build-profile=optimized',
@@ -142,7 +141,7 @@ class SimulationRunner(object):
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         # Build ns-3
-        build_process = subprocess.Popen(['python', 'waf', 'build'],
+        build_process = subprocess.Popen(['python3', 'waf', 'build'],
                                          cwd=self.path,
                                          stdout=subprocess.PIPE,
                                          stderr=subprocess.PIPE)
@@ -299,7 +298,7 @@ class SimulationRunner(object):
             if return_code > 0:
                 complete_command = [self.script]
                 complete_command.extend(command[1:])
-                complete_command = "python waf --run \"%s\"" % (
+                complete_command = "python3 waf --run \"%s\"" % (
                     ' '.join(complete_command))
 
                 with open(stdout_file_path, 'r') as stdout_file, open(

--- a/sem/utils.py
+++ b/sem/utils.py
@@ -55,11 +55,11 @@ def get_command_from_result(script, result, debug=False):
             template.
     """
     if not debug:
-        command = "python waf --run \"" + script + " " + " ".join(
+        command = "python3 waf --run \"" + script + " " + " ".join(
             ['--%s=%s' % (param, value) for param, value in
              result['params'].items()]) + "\""
     else:
-        command = "python waf --run " + script + " --command-template=\"" +\
+        command = "python3 waf --run " + script + " --command-template=\"" +\
             "gdb --args %s " + " ".join(['--%s=%s' % (param, value) for
                                          param, value in
                                          result['params'].items()]) + "\""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,7 +134,7 @@ def get_and_compile_ns_3():
     if not os.path.exists(ns_3_test_compiled_debug):
         shutil.copytree(ns_3_test, ns_3_test_compiled_debug, symlinks=True)
 
-    if subprocess.call(['python', 'waf', 'configure', '--disable-gtk',
+    if subprocess.call(['python3', 'waf', 'configure', '--disable-gtk',
                         '--disable-python', '--build-profile=optimized',
                         '--out=build/optimized', 'build'],
                        cwd=ns_3_test_compiled,
@@ -142,7 +142,7 @@ def get_and_compile_ns_3():
                        stderr=subprocess.STDOUT) > 0:
         raise Exception("Test build failed.")
 
-    if subprocess.call(['python', 'waf', 'configure', '--disable-gtk',
+    if subprocess.call(['python3', 'waf', 'configure', '--disable-gtk',
                         '--disable-python', '--build-profile=debug',
                         '--out=build', 'build'],
                        cwd=ns_3_test_compiled_debug,
@@ -150,7 +150,7 @@ def get_and_compile_ns_3():
                        stderr=subprocess.STDOUT) > 0:
         raise Exception("Test build failed.")
 
-    if subprocess.call(['python', 'waf', 'configure', '--disable-gtk',
+    if subprocess.call(['python3', 'waf', 'configure', '--disable-gtk',
                         '--disable-python', '--build-profile=optimized',
                         '--out=build/optimized', 'build'],
                        cwd=ns_3_examples,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -7,4 +7,4 @@ def test_examples():
     for f in python_files:
         if f.endswith('.py'):
             print("Executing %s" % f)
-            subprocess.call(['python', "examples/%s" % f])
+            subprocess.call(['python3', "examples/%s" % f])


### PR DESCRIPTION
In Ubuntu 18.04 the default python version is Python 2.7 however, ns-3.31 builds only with Python3.5+. 
The provided patch ensures that Python 3 is always used to configure, build and run simulations, even in a Python-2-based system.
 