### PR TITLE
fix: replaced atributes. in database.py::DatabaseManger.wipr_results(…

### DIFF
--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -53,7 +53,7 @@ def test_script_without_args(ns_3_compiled):
 
 
 def test_empty_param_list(ns_3_compiled, config, parameter_combination):
-    runner = SimulationRunner(ns_3_compiled, 'error-throwing-example')
-    data_dir = os.path.join(config['campaign_dir'], 'data')
     with pytest.raises(Exception):
+        runner = SimulationRunner(ns_3_compiled, 'error-throwing-example')
+        data_dir = os.path.join(config['campaign_dir'], 'data')
         list(runner.run_simulations([parameter_combination], data_dir))


### PR DESCRIPTION
…){db.db.purge_tabel} &

test_database.py.test_db_loading(){db.db.purge_tabel} (is no longer exist) &
test_runner.py::test_empty_param_list()(runner & data_dir should be in the block of pytest.raises(Exception))
runner.py::SimulationRunner.get_availabel_parameters(){in valid scape sequence '\s' replaced by '\s'} &
conftest.py::config(){commit is updated as conftes.py::maneger() is updated}. -
refactor: deprication in conftest.py.
@pytest.yalid_fixture() is depricated with @pytest.fixture()