### PR TITLE
fix: bugs in test cases, runner and databse

### DIFF
--- a/sem/database.py
+++ b/sem/database.py
@@ -417,7 +417,7 @@ class DatabaseManager(object):
         This also removes all output files, and cannot be undone.
         """
         # Clean results table
-        self.db.purge_table('results')
+        self.db.drop_table('results')
         self.write_to_disk()
 
         # Get rid of contents of data dir

--- a/sem/runner.py
+++ b/sem/runner.py
@@ -196,8 +196,8 @@ class SimulationRunner(object):
                                          cwd=self.path).decode('utf-8')
 
         # Isolate the list of parameters
-        options = re.findall('.*Program\s(?:Options|Arguments):'
-                             '(.*)General\sArguments.*',
+        options = re.findall('.*Program\\s(?:Options|Arguments):'
+                             '(.*)General\\sArguments.*',
                              result, re.DOTALL)
 
         global_options = subprocess.check_output([self.script_executable,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,7 @@ def ns_3_compiled_debug(tmpdir):
 def config(tmpdir, ns_3_compiled):
     return {
         'script': 'hash-example',
-        'commit': 'e060e93f468d32a5e0dab04cf780d30d4f5bd618',
+        'commit': 'ee614023659b78a115da123a00c8966f965bc202',
         'params': ['dict', 'time'],
         'campaign_dir': str(tmpdir.join('test_campaign')),
     }
@@ -164,7 +164,7 @@ def get_and_compile_ns_3():
 #########################################################################
 
 
-@pytest.yield_fixture(autouse=True, scope='function')
+@pytest.fixture(autouse=True, scope='function')
 def setup_and_cleanup(tmpdir):
     yield
     shutil.rmtree(str(tmpdir))

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -48,7 +48,7 @@ def test_db_loading(config, db, tmpdir):
     assert db.get_config() == config
 
     # Modify the campaign database, removing an entry
-    db.db.purge_table('config')
+    db.db.drop_table('config')
     db.db.storage.flush()
 
     # Wrong database format is currently detected

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -53,7 +53,7 @@ def test_script_without_args(ns_3_compiled):
 
 
 def test_empty_param_list(ns_3_compiled, config, parameter_combination):
-    runner = SimulationRunner(ns_3_compiled, 'error-throwing-example')
-    data_dir = os.path.join(config['campaign_dir'], 'data')
     with pytest.raises(Exception):
+        runner = SimulationRunner(ns_3_compiled, 'error-throwing-example')
+        data_dir = os.path.join(config['campaign_dir'], 'data')
         list(runner.run_simulations([parameter_combination], data_dir))


### PR DESCRIPTION
database.py::DatabaseManger.wipr_results(){db.db.purge_tabel} &
test_database.py.test_db_loading(){db.db.purge_tabel} (is no longer exist) &
test_runner.py::test_empty_param_list()(runner & data_dir should be in the block of pytest.raises(Exception))
runner.py::SimulationRunner.get_availabel_parameters(){in valid scape sequence '\s' replaced by '\s'} &
conftest.py::config(){commit is updated as conftes.py::maneger() is updated}. -
refactor: deprication in conftest.py.
@pytest.yalid_fixture() is depricated with @pytest.fixture()