### PR TITLE
Try to identify out of memory errors and print corresponding error message

### DIFF
--- a/sem/runner.py
+++ b/sem/runner.py
@@ -329,8 +329,7 @@ class SimulationRunner(object):
             if return_code != 0:
                 with open(stdout_file_path, 'r') as stdout_file, open(
                         stderr_file_path, 'r') as stderr_file:
-                    common_error_message = ('\nSimulation exited with an error.\n'
-                                            'Params: %s\n'
+                    common_error_message = ('Params: %s\n'
                                             'Stderr: %s\n'
                                             'Stdout: %s\n'
                                             % (parameter,
@@ -338,12 +337,13 @@ class SimulationRunner(object):
                                                stdout_file.read()))
                     if return_code == SIGKILL_CODE:
                         error_message = common_error_message + \
-                                        'Simulation likely killed due to an out of memory error.\n' + \
-                                        'Check kernel logs (dmesg, for instance) to confirm.'
+                                        '\nSimulation likely killed due to an out of memory error.\n' + \
+                                        'Check kernel logs (dmesg, for instance) to confirm\n.'
                     else:
                         complete_command = sem.utils.get_command_from_result(self.script, current_result)
                         complete_command_debug = sem.utils.get_command_from_result(self.script, current_result, debug=True)
-                        error_message = common_error_message + \
+                        error_message = '\nSimulation exited with an error.\n' + \
+                                        common_error_message + \
                                         ('Use this command to reproduce:\n'
                                          '%s\n'
                                          'Debug with gdb:\n'

--- a/sem/runner.py
+++ b/sem/runner.py
@@ -350,9 +350,10 @@ class SimulationRunner(object):
                                          '%s'
                                          % (complete_command,
                                             complete_command_debug))
-                        if stop_on_errors:
-                            raise Exception(error_message)
-                        print(error_message)                                    
+                                            
+                    if stop_on_errors:
+                        raise Exception(error_message)
+                    print(error_message)                                    
 
             current_result['meta']['elapsed_time'] = end-start
             current_result['meta']['exitcode'] = return_code

--- a/sem/runner.py
+++ b/sem/runner.py
@@ -345,6 +345,8 @@ class SimulationRunner(object):
                     if stop_on_errors:
                         raise Exception(error_message)
                     print(error_message)
+                    print('Return code:')
+                    print(return_code)
 
             current_result['meta']['elapsed_time'] = end-start
             current_result['meta']['exitcode'] = return_code

--- a/sem/runner.py
+++ b/sem/runner.py
@@ -9,7 +9,7 @@ import sem.utils
 from tqdm import tqdm
 from typing import Final
 
-SIGKILL_CODE: Final = -9    # Return code used to identify out of memory events.
+SIGKILL_CODE: Final = -9    # POSIX return code which usually corresponds to out of memory events.
 
 class SimulationRunner(object):
     """
@@ -337,7 +337,7 @@ class SimulationRunner(object):
                                                stdout_file.read()))
                     if return_code == SIGKILL_CODE:
                         error_message = '\nSimulation likely killed due to an out of memory error.\n' + \
-                                        'Check kernel logs (dmesg, for instance) to confirm\n.' + \
+                                        'Check kernel logs (dmesg, for instance) to confirm.\n' + \
                                         common_error_message 
                     else:
                         complete_command = sem.utils.get_command_from_result(self.script, current_result)

--- a/sem/runner.py
+++ b/sem/runner.py
@@ -1,14 +1,15 @@
 import importlib
 import os
 import re
-from signal import SIGKILL
 import subprocess
 import time
 import uuid
 import sem.utils
 
 from tqdm import tqdm
+from typing import Final
 
+SIGKILL_CODE: Final = -9    # Return code used to identify out of memory events.
 
 class SimulationRunner(object):
     """
@@ -335,7 +336,7 @@ class SimulationRunner(object):
                                             % (parameter,
                                                stderr_file.read(),
                                                stdout_file.read()))
-                    if return_code == SIGKILL:
+                    if return_code == SIGKILL_CODE:
                         error_message = common_error_message + \
                                         'Simulation likely killed due to an out of memory error.\n' + \
                                         'Check kernel logs (dmesg, for instance) to confirm.'

--- a/sem/runner.py
+++ b/sem/runner.py
@@ -336,9 +336,9 @@ class SimulationRunner(object):
                                                stderr_file.read(),
                                                stdout_file.read()))
                     if return_code == SIGKILL_CODE:
-                        error_message = common_error_message + \
-                                        '\nSimulation likely killed due to an out of memory error.\n' + \
-                                        'Check kernel logs (dmesg, for instance) to confirm\n.'
+                        error_message = '\nSimulation likely killed due to an out of memory error.\n' + \
+                                        'Check kernel logs (dmesg, for instance) to confirm\n.' + \
+                                        common_error_message 
                     else:
                         complete_command = sem.utils.get_command_from_result(self.script, current_result)
                         complete_command_debug = sem.utils.get_command_from_result(self.script, current_result, debug=True)


### PR DESCRIPTION
This PR aims to identify simulation crashes due to out of memory errors. Indeed, in these cases the simulation script is terminated by the kernel with signal `SIGKILL` (on POSIX systems), and no errors are shown in either `stdout` or `stderr`. Instead, with these changes the user will be informed of the likely cause of the crash.

P.S. I could not find a definition of the `SIGKILL` return code, so I not-so-elegantly defined it myself. Feel free to propose a different approach if a more elegant solutions comes to mind :)