### PR TITLE
Introduce support for CMake-based ns-3 versions and fix tests

### DIFF
--- a/.github/workflows/build-and-push-docs.yml
+++ b/.github/workflows/build-and-push-docs.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.8'
     - name: Install Poetry

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3
@@ -24,7 +24,7 @@ jobs:
     - name: Install GCC
       uses: egor-tensin/setup-gcc@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Poetry

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
     - name: Install GCC

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        submodules: 'true'
+        submodules: 'recursive'
         
     - name: Install GCC
       uses: egor-tensin/setup-gcc@v1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        submodules: 'recursive'
+        submodules: 'true'
+        
     - name: Install GCC
       uses: egor-tensin/setup-gcc@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "examples/ns-3"]
-	path = examples/ns-3
-	url = https://gitlab.com/nsnam/ns-3-dev.git
-	branch = ac88b75eac1818c673cf2c939a96ac3005b1f051

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "examples/ns-3"]
 	path = examples/ns-3
-	url = https://gitlab.com/nsnam/ns-3-dev
-	branch = ns-3.35
+	url = https://gitlab.com/nsnam/ns-3-dev.git
+	branch = ac88b75eac1818c673cf2c939a96ac3005b1f051

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "examples/ns-3"]
+	path = examples/ns-3
+	url = https://gitlab.com/nsnam/ns-3-dev.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "examples/ns-3"]
 	path = examples/ns-3
-	url = https://github.com/signetlabdei/sem-ns-3-dev
-	branch = sem-examples
+	url = https://gitlab.com/nsnam/ns-3-dev
+	branch = ns-3.35

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sem"
-version = "0.3.4"
+version = "0.3.5"
 description = "A Simulation Execution Manager for ns-3"
 authors = ["Davide Magrin <magrinda@dei.unipd.it>"]
 license = "GPL-2.0-only"

--- a/sem/cli.py
+++ b/sem/cli.py
@@ -8,6 +8,7 @@ import re
 import glob
 import shutil
 from tinydb import TinyDB
+from tinydb.table import Document
 
 
 @click.group()
@@ -360,10 +361,15 @@ def merge(move, output_dir, sources):
     db.table('config').insert_multiple(reference_config.all())
 
     # Import results from all databases to the new JSON file
+    new_doc_id = 1
     for s in sources:
         filename = "%s.json" % os.path.split(s)[1]
         current_db = TinyDB(os.path.join(s, filename))
-        db.table('results').insert_multiple(current_db.table('results').all())
+
+        # Assign a globally unique document ID to the result entries
+        for result in current_db.table('results').all():
+            db.table('results').insert(Document(result, doc_id=new_doc_id))
+            new_doc_id = new_doc_id + 1
 
     # Copy or move results to new data folder
     for s in sources:

--- a/sem/runner.py
+++ b/sem/runner.py
@@ -150,7 +150,7 @@ class SimulationRunner(object):
                 and only perform compilation.
         """
 
-        build_program = "ns3" if os.path.exists(os.path.join(self.path, "ns3")) else "waf"
+        build_program = "./ns3" if os.path.exists(os.path.join(self.path, "ns3")) else "./waf"
 
         # Only configure if necessary
         if not skip_configuration:

--- a/sem/runner.py
+++ b/sem/runner.py
@@ -110,7 +110,8 @@ class SimulationRunner(object):
         self.script_executable = max(match_percentages,
                                      key=lambda x: x['percentage'])['path']
 
-        if "scratch" in self.script_executable:
+        # This step is not needed for CMake versions of ns-3
+        if "scratch" in self.script_executable and not os.path.exists(os.path.join(self.path, "ns3")):
             path_with_subdir = self.script_executable.split("/scratch/")[-1]
             if ("/" in path_with_subdir):  # Script is in a subdir
                 executable_subpath = "%s/%s" % (self.script, self.script)

--- a/sem/runner.py
+++ b/sem/runner.py
@@ -63,17 +63,24 @@ class SimulationRunner(object):
 
         # ns-3's build status output is used to get the executable path for the
         # specified script.
-        if optimized:
-            build_status_path = os.path.join(path,
-                                             'build/optimized/build-status.py')
+        if os.path.exists(os.path.join(self.path, "ns3")):
+            build_status_path = os.path.join(path, '.lock-ns3_linux_build')
         else:
-            build_status_path = os.path.join(path,
-                                             'build/build-status.py')
+            if optimized:
+                build_status_path = os.path.join(path,
+                                                'build/optimized/build-status.py')
+            else:
+                build_status_path = os.path.join(path,
+                                                'build/build-status.py')
 
         # By importing the file, we can naturally get the dictionary
         try:  # This only works on Python >= 3.5
-            spec = importlib.util.spec_from_file_location('build_status',
-                                                          build_status_path)
+            if os.path.exists(os.path.join(self.path, "ns3")):
+                spec = importlib.util.spec_from_file_location('.lock-ns3_linux_build',
+                                                            build_status_path)
+            else:
+                spec = importlib.util.spec_from_file_location('build_status',
+                                                            build_status_path)
             build_status = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(build_status)
         except (AttributeError):  # This happens in Python <= 3.4

--- a/sem/runner.py
+++ b/sem/runner.py
@@ -170,8 +170,7 @@ class SimulationRunner(object):
         j_argument = ['-j', str(self.max_parallel_processes)] if self.max_parallel_processes else []
         build_process = subprocess.Popen(['python3', build_program] + j_argument + ['build'],
                                          cwd=self.path,
-                                         stdout=subprocess.PIPE,
-                                         stderr=subprocess.PIPE)
+                                         stdout=subprocess.PIPE)
 
         # Show a progress bar
         if show_progress:
@@ -215,9 +214,8 @@ class SimulationRunner(object):
             if output == b'' and process.poll() is not None:
                 if process.returncode > 0:
                     raise Exception("Compilation ended with an error"
-                                    ".\nSTDERR\n%s\nSTDOUT\n%s" %
-                                    (process.stderr.read(),
-                                     process.stdout.read()))
+                                    ".\nSTDOUT\n%s" %
+                                    (process.stdout.read()))
                 return
             if output:
                 if build_program == "ns3":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,14 +115,14 @@ def result(config):
 @pytest.fixture(scope='function')
 def parameter_combination_no_rngrun():
     # We need to explicitly state we want an OrderedDict here in order to
-    # support python3 < 3.6 - since python3 3.6, dicts are ordered by default
+    # support Python < 3.6 - since Python 3.6, dicts are ordered by default
     return collections.OrderedDict([('dict', '/usr/share/dict/american-english'),
                                     ('time', False)])
 
 @pytest.fixture(scope='function')
 def parameter_combination():
     # We need to explicitly state we want an OrderedDict here in order to
-    # support python3 < 3.6 - since python3 3.6, dicts are ordered by default
+    # support Python < 3.6 - since Python 3.6, dicts are ordered by default
     return collections.OrderedDict([('dict', '/usr/share/dict/american-english'),
                                     ('time', False),
                                     ('RngRun', '0')])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,7 +96,7 @@ def config(tmpdir, ns_3_compiled):
 def result(config):
     r = {
         'params': collections.OrderedDict(
-            [('dict', '/usr/share/dict/web2'),
+            [('dict', '/usr/share/dict/american-english'),
              ('time', False),
              ('RngRun', 10)]),
         'meta': {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,11 +39,18 @@ def ns_3_compiled(tmpdir):
     # Relocate build by running the same command in the new directory
     if subprocess.call(['python', build_program, 'configure', '--disable-gtk',
                         '--build-profile=optimized',
-                        '--out=build/optimized', 'build'],
+                        '--out=build/optimized'],
+                       cwd=ns_3_tempdir,
+                       stdout=subprocess.DEVNULL,
+                       stderr=subprocess.DEVNULL) > 0:
+        raise Exception("Configuration failed")
+    
+    if subprocess.call(['python', build_program, 'build'],
                        cwd=ns_3_tempdir,
                        stdout=subprocess.DEVNULL,
                        stderr=subprocess.DEVNULL) > 0:
         raise Exception("Build failed")
+
     return ns_3_tempdir
 
 
@@ -58,11 +65,18 @@ def ns_3_compiled_debug(tmpdir):
     # Relocate build by running the same command in the new directory
     if subprocess.call(['python', build_program, 'configure', '--disable-gtk',
                         '--build-profile=debug',
-                        '--out=build', 'build'],
+                        '--out=build'],
+                       cwd=ns_3_tempdir,
+                       stdout=subprocess.DEVNULL,
+                       stderr=subprocess.DEVNULL) > 0:
+        raise Exception("Configuration failed")
+    
+    if subprocess.call(['python', build_program, 'build'],
                        cwd=ns_3_tempdir,
                        stdout=subprocess.DEVNULL,
                        stderr=subprocess.DEVNULL) > 0:
         raise Exception("Build failed")
+
     return ns_3_tempdir
 
 
@@ -131,8 +145,7 @@ def manager(ns_3_compiled, config):
 def get_and_compile_ns_3():
     # Clone ns-3
     if not os.path.exists(ns_3_test):
-        Repo.clone_from('http://github.com/signetlabdei/sem-ns-3-dev.git', ns_3_test,
-                        branch='sem-tests')
+        Repo.clone_from('https://gitlab.com/nsnam/ns-3-dev.git', ns_3_test)
 
     # Copy folder to compile in optimized mode
     if not os.path.exists(ns_3_test_compiled):
@@ -146,30 +159,48 @@ def get_and_compile_ns_3():
 
     if subprocess.call(['python3', build_program, 'configure', '--disable-gtk',
                         '--build-profile=optimized',
-                        '--out=build/optimized', 'build'],
+                        '--out=build/optimized'],
                        cwd=ns_3_test_compiled,
                        stdout=subprocess.DEVNULL,
                        stderr=subprocess.STDOUT) != 0:
+        raise Exception("Optimized test configuration failed.")
+    
+    if subprocess.call(['python', build_program, 'build'],
+                       cwd=ns_3_test_compiled,
+                       stdout=subprocess.DEVNULL,
+                       stderr=subprocess.DEVNULL) > 0:
         raise Exception("Optimized test build failed.")
 
     build_program = get_build_program(ns_3_test_compiled_debug)
 
     if subprocess.call(['python3', build_program, 'configure', '--disable-gtk',
                         '--build-profile=debug',
-                        '--out=build', 'build'],
+                        '--out=build'],
                        cwd=ns_3_test_compiled_debug,
                        stdout=subprocess.DEVNULL,
                        stderr=subprocess.STDOUT) != 0:
+        raise Exception("Debug test configuration failed.")
+    
+    if subprocess.call(['python', build_program, 'build'],
+                       cwd=ns_3_test_compiled,
+                       stdout=subprocess.DEVNULL,
+                       stderr=subprocess.DEVNULL) > 0:
         raise Exception("Debug test build failed.")
 
     build_program = get_build_program(ns_3_examples)
 
     if subprocess.call(['python3', build_program, 'configure', '--disable-gtk',
                         '--build-profile=optimized',
-                        '--out=build/optimized', 'build'],
+                        '--out=build/optimized'],
                        cwd=ns_3_examples,
                        stdout=subprocess.DEVNULL,
                        stderr=subprocess.STDOUT) != 0:
+        raise Exception("Examples configuration failed.")
+    
+    if subprocess.call(['python', build_program, 'build'],
+                       cwd=ns_3_test_compiled,
+                       stdout=subprocess.DEVNULL,
+                       stderr=subprocess.DEVNULL) > 0:
         raise Exception("Examples build failed.")
 
 #########################################################################

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,7 +193,7 @@ def get_and_compile_ns_3():
         raise Exception("Debug test configuration failed.")
     
     if subprocess.call([build_program, 'build'],
-                       cwd=ns_3_test_compiled,
+                       cwd=ns_3_test_compiled_debug,
                        stdout=subprocess.DEVNULL,
                        stderr=subprocess.DEVNULL) > 0:
         raise Exception("Debug test build failed.")
@@ -207,7 +207,6 @@ def get_and_compile_ns_3():
                        cwd=ns_3_examples,
                        stdout=subprocess.DEVNULL,
                        stderr=subprocess.STDOUT) != 0:
-
         raise Exception("Examples configuration failed.")
     
     if subprocess.call([build_program, 'build'],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,9 +144,8 @@ def parameter_combination_range():
 
 @pytest.fixture(scope='function')
 def manager(ns_3_compiled, config):
-    manager = CampaignManager.new(ns_3_compiled, config['script'],
+    return CampaignManager.new(ns_3_compiled, config['script'],
                                config['campaign_dir'])
-    return manager
 
 
 def get_and_compile_ns_3():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,9 @@ def ns_3(tmpdir):
 def ns_3_compiled(tmpdir):
     # Copy the test ns-3 installation in the temporary directory
     ns_3_tempdir = str(tmpdir.join('ns-3-compiled'))
-    shutil.copytree(ns_3_test_compiled, ns_3_tempdir, symlinks=True)
+    shutil.copytree(ns_3_test_compiled, ns_3_tempdir, symlinks=True, 
+                    # Do not copy cmake's cache, as it is directory-dependant 
+                    ignore=shutil.ignore_patterns("cmake-cache"))  
 
     build_program = get_build_program(ns_3_tempdir)
 
@@ -155,9 +157,13 @@ def get_and_compile_ns_3():
     if not os.path.exists(ns_3_test_compiled_debug):
         shutil.copytree(ns_3_test, ns_3_test_compiled_debug, symlinks=True)
 
+    # Copy folder to run examples
+    if not os.path.exists(ns_3_examples):
+        shutil.copytree(ns_3_test, ns_3_examples, symlinks=True)
+
     build_program = get_build_program(ns_3_test_compiled)
 
-    if subprocess.call(['python3', build_program, 'configure', '--disable-gtk',
+    if subprocess.call(['python', build_program, 'configure', '--disable-gtk',
                         '--build-profile=optimized',
                         '--out=build/optimized'],
                        cwd=ns_3_test_compiled,
@@ -173,7 +179,7 @@ def get_and_compile_ns_3():
 
     build_program = get_build_program(ns_3_test_compiled_debug)
 
-    if subprocess.call(['python3', build_program, 'configure', '--disable-gtk',
+    if subprocess.call(['python', build_program, 'configure', '--disable-gtk',
                         '--build-profile=debug',
                         '--out=build'],
                        cwd=ns_3_test_compiled_debug,
@@ -189,12 +195,13 @@ def get_and_compile_ns_3():
 
     build_program = get_build_program(ns_3_examples)
 
-    if subprocess.call(['python3', build_program, 'configure', '--disable-gtk',
+    if subprocess.call(['python', build_program, 'configure', '--disable-gtk',
                         '--build-profile=optimized',
                         '--out=build/optimized'],
                        cwd=ns_3_examples,
                        stdout=subprocess.DEVNULL,
                        stderr=subprocess.STDOUT) != 0:
+
         raise Exception("Examples configuration failed.")
     
     if subprocess.call(['python', build_program, 'build'],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ def get_build_program(ns_3_dir):
     if os.path.exists(os.path.join(ns_3_dir, "ns3")):
         return "./ns3"
     else:
-        return "python3 ./waf"
+        return "./waf"
 
 @pytest.fixture(scope='function')
 def ns_3(tmpdir):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,7 @@ def ns_3_compiled(tmpdir):
 
     # Relocate build by running the same command in the new directory
     if subprocess.call([build_program, 'configure', '--disable-gtk',
-                        '--build-profile=optimized',
+                        '--build-profile=optimized', '--enable-modules=core',
                         '--out=build/optimized'],
                        cwd=ns_3_tempdir,
                        stdout=subprocess.DEVNULL,
@@ -70,7 +70,7 @@ def ns_3_compiled_debug(tmpdir):
 
     # Relocate build by running the same command in the new directory
     if subprocess.call([build_program, 'configure', '--disable-gtk',
-                        '--build-profile=debug',
+                        '--build-profile=debug', '--enable-modules=core',
                         '--out=build'],
                        cwd=ns_3_tempdir,
                        stdout=subprocess.DEVNULL,
@@ -150,7 +150,7 @@ def manager(ns_3_compiled, config):
 
 
 def get_and_compile_ns_3():
-    # Clone ns-3
+    # Clone latest ns-3
     if not os.path.exists(ns_3_test):
         Repo.clone_from('https://gitlab.com/nsnam/ns-3-dev.git', ns_3_test)
 
@@ -164,18 +164,12 @@ def get_and_compile_ns_3():
     if not os.path.exists(ns_3_test_compiled_debug):
         shutil.copytree(ns_3_test, ns_3_test_compiled_debug, symlinks=True,
                         # Do not copy cmake's cache, as it is directory-dependant 
-                        ignore=shutil.ignore_patterns("cmake-cache"))  
-
-    # Copy folder to run examples
-    if not os.path.exists(ns_3_examples):
-        shutil.copytree(ns_3_test, ns_3_examples, symlinks=True,
-                        # Do not copy cmake's cache, as it is directory-dependant 
-                        ignore=shutil.ignore_patterns("cmake-cache"))  
+                        ignore=shutil.ignore_patterns("cmake-cache"))    
 
     build_program = get_build_program(ns_3_test_compiled)
 
     if subprocess.call([build_program, 'configure', '--disable-gtk',
-                        '--build-profile=optimized',
+                        '--build-profile=optimized', '--enable-modules=core',
                         '--out=build/optimized'],
                        cwd=ns_3_test_compiled,
                        stdout=subprocess.DEVNULL,
@@ -191,7 +185,7 @@ def get_and_compile_ns_3():
     build_program = get_build_program(ns_3_test_compiled_debug)
 
     if subprocess.call([build_program, 'configure', '--disable-gtk',
-                        '--build-profile=debug',
+                        '--build-profile=debug', '--enable-modules=core',
                         '--out=build'],
                        cwd=ns_3_test_compiled_debug,
                        stdout=subprocess.DEVNULL,
@@ -204,10 +198,11 @@ def get_and_compile_ns_3():
                        stderr=subprocess.DEVNULL) > 0:
         raise Exception("Debug test build failed.")
 
+    # Configure and build WAF-based ns-3
     build_program = get_build_program(ns_3_examples)
 
     if subprocess.call([build_program, 'configure', '--disable-gtk',
-                        '--build-profile=optimized',
+                        '--build-profile=optimized', '--enable-modules=core',
                         '--out=build/optimized'],
                        cwd=ns_3_examples,
                        stdout=subprocess.DEVNULL,
@@ -216,7 +211,7 @@ def get_and_compile_ns_3():
         raise Exception("Examples configuration failed.")
     
     if subprocess.call([build_program, 'build'],
-                       cwd=ns_3_test_compiled,
+                       cwd=ns_3_examples,
                        stdout=subprocess.DEVNULL,
                        stderr=subprocess.DEVNULL) > 0:
         raise Exception("Examples build failed.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,9 +16,9 @@ ns_3_test_compiled_debug = os.path.join(os.path.dirname(os.path.realpath(__file_
 
 def get_build_program(ns_3_dir):
     if os.path.exists(os.path.join(ns_3_dir, "ns3")):
-        return "ns3"
+        return "./ns3"
     else:
-        return "waf"
+        return "./waf"
 
 @pytest.fixture(scope='function')
 def ns_3(tmpdir):
@@ -39,7 +39,7 @@ def ns_3_compiled(tmpdir):
     build_program = get_build_program(ns_3_tempdir)
 
     # Relocate build by running the same command in the new directory
-    if subprocess.call(['python', build_program, 'configure', '--disable-gtk',
+    if subprocess.call(['python3', build_program, 'configure', '--disable-gtk',
                         '--build-profile=optimized',
                         '--out=build/optimized'],
                        cwd=ns_3_tempdir,
@@ -47,7 +47,7 @@ def ns_3_compiled(tmpdir):
                        stderr=subprocess.DEVNULL) > 0:
         raise Exception("Configuration failed")
     
-    if subprocess.call(['python', build_program, 'build'],
+    if subprocess.call(['python3', build_program, 'build'],
                        cwd=ns_3_tempdir,
                        stdout=subprocess.DEVNULL,
                        stderr=subprocess.DEVNULL) > 0:
@@ -65,7 +65,7 @@ def ns_3_compiled_debug(tmpdir):
     build_program = get_build_program(ns_3_tempdir)
 
     # Relocate build by running the same command in the new directory
-    if subprocess.call(['python', build_program, 'configure', '--disable-gtk',
+    if subprocess.call(['python3', build_program, 'configure', '--disable-gtk',
                         '--build-profile=debug',
                         '--out=build'],
                        cwd=ns_3_tempdir,
@@ -73,7 +73,7 @@ def ns_3_compiled_debug(tmpdir):
                        stderr=subprocess.DEVNULL) > 0:
         raise Exception("Configuration failed")
     
-    if subprocess.call(['python', build_program, 'build'],
+    if subprocess.call(['python3', build_program, 'build'],
                        cwd=ns_3_tempdir,
                        stdout=subprocess.DEVNULL,
                        stderr=subprocess.DEVNULL) > 0:
@@ -111,14 +111,14 @@ def result(config):
 @pytest.fixture(scope='function')
 def parameter_combination_no_rngrun():
     # We need to explicitly state we want an OrderedDict here in order to
-    # support Python < 3.6 - since Python 3.6, dicts are ordered by default
+    # support python3 < 3.6 - since python3 3.6, dicts are ordered by default
     return collections.OrderedDict([('dict', '/usr/share/dict/web2'),
                                     ('time', False)])
 
 @pytest.fixture(scope='function')
 def parameter_combination():
     # We need to explicitly state we want an OrderedDict here in order to
-    # support Python < 3.6 - since Python 3.6, dicts are ordered by default
+    # support python3 < 3.6 - since python3 3.6, dicts are ordered by default
     return collections.OrderedDict([('dict', '/usr/share/dict/web2'),
                                     ('time', False),
                                     ('RngRun', '0')])
@@ -163,7 +163,7 @@ def get_and_compile_ns_3():
 
     build_program = get_build_program(ns_3_test_compiled)
 
-    if subprocess.call(['python', build_program, 'configure', '--disable-gtk',
+    if subprocess.call(['python3', build_program, 'configure', '--disable-gtk',
                         '--build-profile=optimized',
                         '--out=build/optimized'],
                        cwd=ns_3_test_compiled,
@@ -171,7 +171,7 @@ def get_and_compile_ns_3():
                        stderr=subprocess.STDOUT) != 0:
         raise Exception("Optimized test configuration failed.")
     
-    if subprocess.call(['python', build_program, 'build'],
+    if subprocess.call(['python3', build_program, 'build'],
                        cwd=ns_3_test_compiled,
                        stdout=subprocess.DEVNULL,
                        stderr=subprocess.DEVNULL) > 0:
@@ -179,7 +179,7 @@ def get_and_compile_ns_3():
 
     build_program = get_build_program(ns_3_test_compiled_debug)
 
-    if subprocess.call(['python', build_program, 'configure', '--disable-gtk',
+    if subprocess.call(['python3', build_program, 'configure', '--disable-gtk',
                         '--build-profile=debug',
                         '--out=build'],
                        cwd=ns_3_test_compiled_debug,
@@ -187,7 +187,7 @@ def get_and_compile_ns_3():
                        stderr=subprocess.STDOUT) != 0:
         raise Exception("Debug test configuration failed.")
     
-    if subprocess.call(['python', build_program, 'build'],
+    if subprocess.call(['python3', build_program, 'build'],
                        cwd=ns_3_test_compiled,
                        stdout=subprocess.DEVNULL,
                        stderr=subprocess.DEVNULL) > 0:
@@ -195,7 +195,7 @@ def get_and_compile_ns_3():
 
     build_program = get_build_program(ns_3_examples)
 
-    if subprocess.call(['python', build_program, 'configure', '--disable-gtk',
+    if subprocess.call(['python3', build_program, 'configure', '--disable-gtk',
                         '--build-profile=optimized',
                         '--out=build/optimized'],
                        cwd=ns_3_examples,
@@ -204,7 +204,7 @@ def get_and_compile_ns_3():
 
         raise Exception("Examples configuration failed.")
     
-    if subprocess.call(['python', build_program, 'build'],
+    if subprocess.call(['python3', build_program, 'build'],
                        cwd=ns_3_test_compiled,
                        stdout=subprocess.DEVNULL,
                        stderr=subprocess.DEVNULL) > 0:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,13 +18,15 @@ def get_build_program(ns_3_dir):
     if os.path.exists(os.path.join(ns_3_dir, "ns3")):
         return "./ns3"
     else:
-        return "./waf"
+        return "python3 ./waf"
 
 @pytest.fixture(scope='function')
 def ns_3(tmpdir):
     # Copy the test ns-3 installation in the temporary directory
     ns_3_tempdir = tmpdir.join('ns-3')
-    shutil.copytree(ns_3_test, str(ns_3_tempdir), symlinks=True)
+    shutil.copytree(ns_3_test, str(ns_3_tempdir), symlinks=True,
+                    # Do not copy cmake's cache, as it is directory-dependant 
+                    ignore=shutil.ignore_patterns("cmake-cache"))  
     return ns_3_tempdir
 
 
@@ -39,7 +41,7 @@ def ns_3_compiled(tmpdir):
     build_program = get_build_program(ns_3_tempdir)
 
     # Relocate build by running the same command in the new directory
-    if subprocess.call(['python3', build_program, 'configure', '--disable-gtk',
+    if subprocess.call([build_program, 'configure', '--disable-gtk',
                         '--build-profile=optimized',
                         '--out=build/optimized'],
                        cwd=ns_3_tempdir,
@@ -47,7 +49,7 @@ def ns_3_compiled(tmpdir):
                        stderr=subprocess.DEVNULL) > 0:
         raise Exception("Configuration failed")
     
-    if subprocess.call(['python3', build_program, 'build'],
+    if subprocess.call([build_program, 'build'],
                        cwd=ns_3_tempdir,
                        stdout=subprocess.DEVNULL,
                        stderr=subprocess.DEVNULL) > 0:
@@ -60,12 +62,14 @@ def ns_3_compiled(tmpdir):
 def ns_3_compiled_debug(tmpdir):
     # Copy the test ns-3 installation in the temporary directory
     ns_3_tempdir = str(tmpdir.join('ns-3-compiled-debug'))
-    shutil.copytree(ns_3_test_compiled_debug, ns_3_tempdir, symlinks=True)
+    shutil.copytree(ns_3_test_compiled_debug, ns_3_tempdir, symlinks=True,
+                    # Do not copy cmake's cache, as it is directory-dependant 
+                    ignore=shutil.ignore_patterns("cmake-cache"))  
 
     build_program = get_build_program(ns_3_tempdir)
 
     # Relocate build by running the same command in the new directory
-    if subprocess.call(['python3', build_program, 'configure', '--disable-gtk',
+    if subprocess.call([build_program, 'configure', '--disable-gtk',
                         '--build-profile=debug',
                         '--out=build'],
                        cwd=ns_3_tempdir,
@@ -73,7 +77,7 @@ def ns_3_compiled_debug(tmpdir):
                        stderr=subprocess.DEVNULL) > 0:
         raise Exception("Configuration failed")
     
-    if subprocess.call(['python3', build_program, 'build'],
+    if subprocess.call([build_program, 'build'],
                        cwd=ns_3_tempdir,
                        stdout=subprocess.DEVNULL,
                        stderr=subprocess.DEVNULL) > 0:
@@ -151,19 +155,25 @@ def get_and_compile_ns_3():
 
     # Copy folder to compile in optimized mode
     if not os.path.exists(ns_3_test_compiled):
-        shutil.copytree(ns_3_test, ns_3_test_compiled, symlinks=True)
+        shutil.copytree(ns_3_test, ns_3_test_compiled, symlinks=True,
+                        # Do not copy cmake's cache, as it is directory-dependant 
+                        ignore=shutil.ignore_patterns("cmake-cache"))  
 
     # Copy folder to compile in debug mode
     if not os.path.exists(ns_3_test_compiled_debug):
-        shutil.copytree(ns_3_test, ns_3_test_compiled_debug, symlinks=True)
+        shutil.copytree(ns_3_test, ns_3_test_compiled_debug, symlinks=True,
+                        # Do not copy cmake's cache, as it is directory-dependant 
+                        ignore=shutil.ignore_patterns("cmake-cache"))  
 
     # Copy folder to run examples
     if not os.path.exists(ns_3_examples):
-        shutil.copytree(ns_3_test, ns_3_examples, symlinks=True)
+        shutil.copytree(ns_3_test, ns_3_examples, symlinks=True,
+                        # Do not copy cmake's cache, as it is directory-dependant 
+                        ignore=shutil.ignore_patterns("cmake-cache"))  
 
     build_program = get_build_program(ns_3_test_compiled)
 
-    if subprocess.call(['python3', build_program, 'configure', '--disable-gtk',
+    if subprocess.call([build_program, 'configure', '--disable-gtk',
                         '--build-profile=optimized',
                         '--out=build/optimized'],
                        cwd=ns_3_test_compiled,
@@ -171,7 +181,7 @@ def get_and_compile_ns_3():
                        stderr=subprocess.STDOUT) != 0:
         raise Exception("Optimized test configuration failed.")
     
-    if subprocess.call(['python3', build_program, 'build'],
+    if subprocess.call([build_program, 'build'],
                        cwd=ns_3_test_compiled,
                        stdout=subprocess.DEVNULL,
                        stderr=subprocess.DEVNULL) > 0:
@@ -179,7 +189,7 @@ def get_and_compile_ns_3():
 
     build_program = get_build_program(ns_3_test_compiled_debug)
 
-    if subprocess.call(['python3', build_program, 'configure', '--disable-gtk',
+    if subprocess.call([build_program, 'configure', '--disable-gtk',
                         '--build-profile=debug',
                         '--out=build'],
                        cwd=ns_3_test_compiled_debug,
@@ -187,7 +197,7 @@ def get_and_compile_ns_3():
                        stderr=subprocess.STDOUT) != 0:
         raise Exception("Debug test configuration failed.")
     
-    if subprocess.call(['python3', build_program, 'build'],
+    if subprocess.call([build_program, 'build'],
                        cwd=ns_3_test_compiled,
                        stdout=subprocess.DEVNULL,
                        stderr=subprocess.DEVNULL) > 0:
@@ -195,7 +205,7 @@ def get_and_compile_ns_3():
 
     build_program = get_build_program(ns_3_examples)
 
-    if subprocess.call(['python3', build_program, 'configure', '--disable-gtk',
+    if subprocess.call([build_program, 'configure', '--disable-gtk',
                         '--build-profile=optimized',
                         '--out=build/optimized'],
                        cwd=ns_3_examples,
@@ -204,7 +214,7 @@ def get_and_compile_ns_3():
 
         raise Exception("Examples configuration failed.")
     
-    if subprocess.call(['python3', build_program, 'build'],
+    if subprocess.call([build_program, 'build'],
                        cwd=ns_3_test_compiled,
                        stdout=subprocess.DEVNULL,
                        stderr=subprocess.DEVNULL) > 0:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,7 +91,7 @@ def config(tmpdir, ns_3_compiled):
     return {
         'script': 'hash-example',
         'commit': Repo(ns_3_compiled).head.commit.hexsha,
-        'params': {'dict': None, 'time': False},
+        'params': {'dict': '/usr/share/dict/words', 'time': False},
         'campaign_dir': str(tmpdir.join('test_campaign')),
     }
 
@@ -144,8 +144,9 @@ def parameter_combination_range():
 
 @pytest.fixture(scope='function')
 def manager(ns_3_compiled, config):
-    return CampaignManager.new(ns_3_compiled, config['script'],
+    manager = CampaignManager.new(ns_3_compiled, config['script'],
                                config['campaign_dir'])
+    return manager
 
 
 def get_and_compile_ns_3():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,29 +112,29 @@ def result(config):
 def parameter_combination_no_rngrun():
     # We need to explicitly state we want an OrderedDict here in order to
     # support python3 < 3.6 - since python3 3.6, dicts are ordered by default
-    return collections.OrderedDict([('dict', '/usr/share/dict/web2'),
+    return collections.OrderedDict([('dict', '/usr/share/dict/american-english'),
                                     ('time', False)])
 
 @pytest.fixture(scope='function')
 def parameter_combination():
     # We need to explicitly state we want an OrderedDict here in order to
     # support python3 < 3.6 - since python3 3.6, dicts are ordered by default
-    return collections.OrderedDict([('dict', '/usr/share/dict/web2'),
+    return collections.OrderedDict([('dict', '/usr/share/dict/american-english'),
                                     ('time', False),
                                     ('RngRun', '0')])
 
 
 @pytest.fixture(scope='function')
 def parameter_combination_2():
-    return collections.OrderedDict([('dict', '/usr/share/dict/web2a'),
+    return collections.OrderedDict([('dict', '/usr/share/dict/british-english'),
                                     ('time', True),
                                     ('RngRun', '0')])
 
 
 @pytest.fixture(scope='function')
 def parameter_combination_range():
-    return collections.OrderedDict([('dict', ['/usr/share/dict/web2',
-                                              '/usr/share/dict/web2a']),
+    return collections.OrderedDict([('dict', ['/usr/share/dict/american-english',
+                                              '/usr/share/dict/british-english']),
                                     ('time', [False, True])])
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,7 @@ def test_cli_run(tmpdir, ns_3_compiled, config):
     runner.invoke(sem.cli, ['run', '--ns-3-path=%s' % ns_3_compiled,
                             '--results-dir=%s' % tmpdir.join('results'),
                             '--script=%s' % config['script']],
-                  input="'/usr/share/dict/web2'\n'false'\n1\n",
+                  input="'/usr/share/dict/american-english'\n'false'\n1\n",
                   catch_exceptions=False)
 
 
@@ -26,7 +26,7 @@ def test_parameters_from_file(tmpdir, ns_3_compiled, config):
     param_file = str(tmpdir.join("parameters.txt"))
     with open(param_file, 'w') as f:
         lines = [
-            "dict: '/usr/share/dict/web2'\n",
+            "dict: '/usr/share/dict/american-english'\n",
             "time: [False, True]"
         ]
         f.writelines(lines)
@@ -62,13 +62,13 @@ def test_cli_merge(tmpdir, ns_3_compiled, config):
     runner.invoke(sem.cli, ['run', '--ns-3-path=%s' % ns_3_compiled,
                             '--results-dir=%s' % tmpdir.join('results_primary'),
                             '--script=%s' % config['script']],
-                  input="'/usr/share/dict/web2'\n'false'\n1\n",
+                  input="'/usr/share/dict/american-english'\n'false'\n1\n",
                   catch_exceptions=False)
 
     runner.invoke(sem.cli, ['run', '--ns-3-path=%s' % ns_3_compiled,
                             '--results-dir=%s' % tmpdir.join('results_secondary'),
                             '--script=%s' % config['script']],
-                  input="'/usr/share/dict/web2'\n'false'\n1\n",
+                  input="'/usr/share/dict/american-english'\n'false'\n1\n",
                   catch_exceptions=False)
 
     runner.invoke(sem.cli, ['merge', str(tmpdir.join('results_merged')),
@@ -79,7 +79,9 @@ def test_cli_merge(tmpdir, ns_3_compiled, config):
     runner.invoke(sem.cli, ['merge', '--move', str(tmpdir.join('results_merged_moved')),
                             str(tmpdir.join('results_primary')),
                             str(tmpdir.join('results_secondary'))],
-                  catch_exceptions=False)
+                  catch_exceptions=False) 
+
+    print("stop here!")
 
     # TODO Check that the new folders actually have all results we expect them
     # to have
@@ -92,7 +94,7 @@ def test_cli_workflow(tmpdir, ns_3_compiled, config):
     runner.invoke(sem.cli, ['run', '--ns-3-path=%s' % ns_3_compiled,
                             '--results-dir=%s' % tmpdir.join('results'),
                             '--script=%s' % config['script']],
-                  input="'/usr/share/dict/web2'\n'false'\n1\n",
+                  input="'/usr/share/dict/american-english'\n'false'\n1\n",
                   catch_exceptions=False)
 
     # Run again, this time defaults should be shown since we have already some
@@ -134,7 +136,7 @@ def test_cli_workflow(tmpdir, ns_3_compiled, config):
     # Accept a query
     runner.invoke(sem.cli, ['view', '--results-dir=%s' %
                             tmpdir.join('results')],
-                  input="['/usr/share/dict/web2']\n['false']\nq",
+                  input="['/usr/share/dict/american-english']\n['false']\nq",
                   catch_exceptions=False)
 
     # Show results including simulation output

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -161,19 +161,19 @@ def test_results_queries(db, result):
     assert sorted([d['params']['RngRun'] for d in results]) == list(range(10))
 
     # Insert other runs for a different parameter combination
-    result['params']['dict'] = '/usr/share/dict/web2a'
+    result['params']['dict'] = '/usr/share/dict/british-english'
     for runIdx in range(10, 20, 1):
         result['params']['RngRun'] = runIdx
         db.insert_result(result)
 
     # This query should return all results
-    results = list(db.get_results({'dict': ['/usr/share/dict/web2a',
-                                       '/usr/share/dict/web2']}))
+    results = list(db.get_results({'dict': ['/usr/share/dict/british-english',
+                                            '/usr/share/dict/american-english']}))
     assert len(results) == 20
     assert sorted([d['params']['RngRun'] for d in results]) == list(range(20))
 
     # This one should only return the second batch
-    results = list(db.get_results({'dict': ['/usr/share/dict/web2a']}))
+    results = list(db.get_results({'dict': ['/usr/share/dict/british-english']}))
     assert len(results) == 10
     assert sorted([d['params']['RngRun'] for d in results]) == list(range(10,
                                                                           20,

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -125,7 +125,7 @@ def test_get_results_as_numpy_array(tmpdir, manager,
 def test_save_to_mat_file(tmpdir, manager, result, parameter_combination):
     mat_file = str(tmpdir.join('results.mat'))
     manager.run_missing_simulations(parameter_combination)
-    manager.save_to_mat_file({'time': 'false', 'dict': '/usr/share/dict/web2'},
+    manager.save_to_mat_file({'time': 'false', 'dict': '/usr/share/dict/american-english'},
                              sem.utils.constant_array_parser,
                              mat_file, 1)
     # Just check the file was created

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -63,7 +63,6 @@ def test_load_campaign(manager, config, parameter_combination):
     del config['campaign_dir']
     assert loaded_manager.db.get_config() == config
     # This campaign should not be able to run simulations
-    #TODO: Why, no runner ? Also how can the two configs be equal ?
     with pytest.raises(Exception):
         loaded_manager.run_simulations([parameter_combination])
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -63,6 +63,7 @@ def test_load_campaign(manager, config, parameter_combination):
     del config['campaign_dir']
     assert loaded_manager.db.get_config() == config
     # This campaign should not be able to run simulations
+    #TODO: Why, no runner ? Also how can the two configs be equal ?
     with pytest.raises(Exception):
         loaded_manager.run_simulations([parameter_combination])
 


### PR DESCRIPTION
This PR completes the support for the newer, `CMake`-based versions of ns-3.

The main changes are:
- Updated CI workflow checkout action from v2 to v3 to solve a related warning.
- Switched to ns-3 mainline repository for the examples/ns-3 submodule. In order to test SEM with both the CMake and the waf versions of ns-3, in this case the repo is checked out at release ns-3.35
- When merging TinyDB tables, re-assign document IDs (which must be unique for each entry) in order to prevent errors.  In this regard, the additional import of `Document` from `tinydb.table` has been added in `cli.py`
- Introduced support for platform-dependent build status filename in ns-3.36+ 
- In the `configure_and_build` function, do not redirect to PIPE stderr when calling `subprocess.Popen ()`. 
 When compiling, you can now get a mix of stdout and stderr output when compilation errors and/or warnings arise. This was causing a race condition between `stdout.readline ()` and `subprocess.poll ()` which caused `get_build_output` to never return. 
It is actually suggested to use `subprocess.communicate ()` as a safer alternative; however, this would not allow us to retrieve the compilation progress. Thus, the proposed solution of missing out on stderr, while at least capturing stdout.
 - Prevented copying CMake cache when creating symlinks in the tests. Previously, this caused errors since the cache is path-dependent. I tried to circumvent this dependence instead of not copying the cache, but I was not able to do it.
 - Enabled only the core module by using the `--enable-modules=core` flag when configuring ns-3 during the tests. Since only such module is needed, this was an obvious choice as it significantly reduces testing time.
 - In the tests, switched from `/usr/share/dict/web2` and `/usr/share/dict/web2a` as input parameters to `/usr/share/dict/american-english` and `/usr/share/dict/british-english`. The previous dictionaries are not installed by default on recent Ubuntu distributions.