### PR TITLE
Update get_command_from_result for ns-3.35+ 

### DIFF
--- a/sem/__init__.py
+++ b/sem/__init__.py
@@ -4,11 +4,11 @@ from .parallelrunner import ParallelRunner
 from .lptrunner import LptRunner
 from .gridrunner import BUILD_GRID_PARAMS, SIMULATION_GRID_PARAMS
 from .database import DatabaseManager
-from .utils import list_param_combinations, automatic_parser, stdout_automatic_parser, only_load_some_files, CallbackBase
+from .utils import list_param_combinations, automatic_parser, stdout_automatic_parser, only_load_some_files, get_command_from_result, CallbackBase
 from .cli import cli
 
 __all__ = ('CampaignManager', 'SimulationRunner', 'ParallelRunner', 'LptRunner',
            'DatabaseManager', 'list_param_combinations', 'automatic_parser',
-           'only_load_some_files', 'CallbackBase')
+           'only_load_some_files', 'get_command_from_result', 'CallbackBase')
 
 name = 'sem'

--- a/sem/__init__.py
+++ b/sem/__init__.py
@@ -4,11 +4,11 @@ from .parallelrunner import ParallelRunner
 from .lptrunner import LptRunner
 from .gridrunner import BUILD_GRID_PARAMS, SIMULATION_GRID_PARAMS
 from .database import DatabaseManager
-from .utils import list_param_combinations, automatic_parser, stdout_automatic_parser, only_load_some_files
+from .utils import list_param_combinations, automatic_parser, stdout_automatic_parser, only_load_some_files, CallbackBase
 from .cli import cli
 
 __all__ = ('CampaignManager', 'SimulationRunner', 'ParallelRunner', 'LptRunner',
            'DatabaseManager', 'list_param_combinations', 'automatic_parser',
-           'only_load_some_files')
+           'only_load_some_files', 'CallbackBase')
 
 name = 'sem'

--- a/sem/cli.py
+++ b/sem/cli.py
@@ -235,9 +235,11 @@ def command(results_dir, result_id):
 
     click.echo("Simulation command:")
     click.echo(sem.utils.get_command_from_result(campaign.db.get_script(),
+                                                 campaign.dir,
                                                  result))
     click.echo("Debug command:")
     click.echo(sem.utils.get_command_from_result(campaign.db.get_script(),
+                                                 campaign.dir,
                                                  result,
                                                  debug=True))
 

--- a/sem/manager.py
+++ b/sem/manager.py
@@ -290,7 +290,7 @@ class CampaignManager(object):
     # Simulation running #
     ######################
 
-    def run_simulations(self, param_list, show_progress=True, stop_on_errors=True):
+    def run_simulations(self, param_list, show_progress=True, callbacks: list = [], stop_on_errors=True):
         """
         Run several simulations specified by a list of parameter combinations.
 
@@ -305,6 +305,10 @@ class CampaignManager(object):
                 can be either a string or a number).
             show_progress (bool): whether or not to show a progress bar with
                 percentage and expected remaining time.
+            callbacks (list): list of objects extending CallbackBase to be 
+                triggered during the run.
+            stop_on_errors (bool): whether or not to stop the execution of the simulations 
+                if an error occurs.
         """
 
         # Make sure we have a runner to run simulations with.
@@ -315,7 +319,7 @@ class CampaignManager(object):
                             " for this CampaignManager.")
 
         # Return if the list is empty
-        if param_list == []:
+        if not param_list:
             return
 
         self.check_and_fill_parameters(param_list, needs_rngrun=True)
@@ -339,6 +343,7 @@ class CampaignManager(object):
         # computation is performed on this line.
         results = self.runner.run_simulations(param_list,
                                               self.db.get_data_dir(),
+                                              callbacks=callbacks,
                                               stop_on_errors=stop_on_errors)
 
         # Wrap the result generator in the progress bar generator.
@@ -377,8 +382,7 @@ class CampaignManager(object):
         self.db.insert_results(results_batch)
         self.db.write_to_disk()
 
-    def get_missing_simulations(self, param_list, runs=None,
-                                with_time_estimate=False):
+    def get_missing_simulations(self, param_list, runs=None, with_time_estimate=False):
         """
         Return a list of the simulations among the required ones that are not
         available in the database.
@@ -389,6 +393,7 @@ class CampaignManager(object):
             runs (int): an integer representing how many repetitions are wanted
                 for each parameter combination, None if the dictionaries in
                 param_list already feature the desired RngRun value.
+            with_time_estimate (bool): a boolean representing ...
         """
 
         params_to_simulate = []
@@ -451,6 +456,7 @@ class CampaignManager(object):
 
     def run_missing_simulations(self, param_list, runs=None,
                                 condition_checking_function=None,
+                                callbacks=[],
                                 stop_on_errors=True):
         """
         Run the simulations from the parameter list that are not yet available
@@ -470,6 +476,10 @@ class CampaignManager(object):
             runs (int): the number of runs to perform for each parameter
                 combination. This parameter is only allowed if the param_list
                 specification doesn't feature an 'RngRun' key already.
+            callbacks (list): list of objects extending CallbackBase to be 
+                triggered during the run.
+            stop_on_errors (bool): whether or not to stop the execution of the simulations 
+                if an error occurs.
         """
         # Expand the parameter specification
         param_list = list_param_combinations(param_list)
@@ -503,10 +513,12 @@ class CampaignManager(object):
                     self.get_missing_simulations(param_list,
                                                  runs,
                                                  with_time_estimate=True),
+                    callbacks=callbacks,
                     stop_on_errors=stop_on_errors)
             else:
                 self.run_simulations(
                     self.get_missing_simulations(param_list, runs),
+                    callbacks=callbacks,
                     stop_on_errors=stop_on_errors)
 
     #####################

--- a/sem/manager.py
+++ b/sem/manager.py
@@ -350,6 +350,7 @@ class CampaignManager(object):
         if show_progress:
             result_generator = tqdm(results, total=len(param_list),
                                     unit='simulation',
+                                    smoothing=0,
                                     desc='Running simulations')
         else:
             result_generator = results

--- a/sem/parallelrunner.py
+++ b/sem/parallelrunner.py
@@ -1,27 +1,45 @@
 from .runner import SimulationRunner
-from multiprocessing import Pool
-
+from .utils import CallbackBase
+from multiprocessing.pool import ThreadPool as Pool
+# We use ThreadPool to share the process memory among the different simulations to enable the use of callbacks.
+# This may be improved eventually using a grain-fined solution that checks the presence or not of callbacks
 
 class ParallelRunner(SimulationRunner):
 
     """
     A Runner which can perform simulations in parallel on the current machine.
     """
+    data_folder: str = None
+    stop_on_errors: bool = False
+    callbacks: [CallbackBase] = []
 
-    def run_simulations(self, parameter_list, data_folder, stop_on_errors=False):
+    def run_simulations(self, parameter_list, data_folder, callbacks: [CallbackBase] = None, stop_on_errors=False):
         """
         This function runs multiple simulations in parallel.
 
         Args:
             parameter_list (list): list of parameter combinations to simulate.
             data_folder (str): folder in which to create output folders.
+            callbacks (list): list of callbacks to be triggered
+            stop_on_errors (bool): check whether simulation has to stop on errors or not
         """
+        
+        if callbacks is not None:
+            for cb in callbacks:
+                cb.on_simulation_start(len(list(enumerate(parameter_list))))
+                cb.controlled_by_parent = True
+
         self.data_folder = data_folder
         self.stop_on_errors = stop_on_errors
+        self.callbacks = callbacks
         with Pool(processes=self.max_parallel_processes) as pool:
             for result in pool.imap_unordered(self.launch_simulation,
                                               parameter_list):
                 yield result
+
+        if callbacks is not None:
+            for cb in callbacks:
+                cb.on_simulation_end()
 
     def launch_simulation(self, parameter):
         """
@@ -35,4 +53,5 @@ class ParallelRunner(SimulationRunner):
         """
         return next(SimulationRunner.run_simulations(self, [parameter],
                                                      self.data_folder,
+                                                     callbacks=self.callbacks,
                                                      stop_on_errors=self.stop_on_errors))

--- a/sem/runner.py
+++ b/sem/runner.py
@@ -352,8 +352,8 @@ class SimulationRunner(object):
 
                 with open(stdout_file_path, 'r') as stdout_file, open(
                         stderr_file_path, 'r') as stderr_file:
-                    complete_command = sem.utils.get_command_from_result(self.script, current_result)
-                    complete_command_debug = sem.utils.get_command_from_result(self.script, current_result, debug=True)
+                    complete_command = sem.utils.get_command_from_result(self.script, self.path, current_result)
+                    complete_command_debug = sem.utils.get_command_from_result(self.script, self.path, current_result, debug=True)
                     error_message = ('\nSimulation exited with an error.\n'
                                      'Params: %s\n'
                                      'Stderr: %s\n'

--- a/sem/utils.py
+++ b/sem/utils.py
@@ -4,6 +4,8 @@ import copy
 import warnings
 from itertools import product
 from functools import wraps
+from abc import ABC, abstractmethod
+from typing import Dict, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -304,6 +306,88 @@ def compute_sensitivity_analysis(
          for p in sem_parameter_list])
     return salib_analyze_function(problem, results)
 
+
+class CallbackBase(ABC):
+    """
+    Base class for SEM callbacks.
+    :param verbose: Verbosity level: 0 for no output, 1 for info messages, 2 for debug messages
+    """
+
+    def __init__(self, verbose: int = 0):
+        super().__init__()
+        # Number of time the callback was called
+        self.controlled_by_parent = False  # type: bool
+        self.n_runs_over = 0  # type: int
+        self.n_runs_over_no_errors = 0  # type: int
+        self.n_runs_over_errors = 0  # type: int
+        self.n_runs_total = 0  # type: int
+        self.run_sim_times = []
+        self.verbose = verbose
+
+    def init_callback(self, controlled_by_parent) -> None:
+        """
+        Initialize the callback.
+        """
+        self.controlled_by_parent = controlled_by_parent
+
+    def is_controlled_by_parent(self) -> bool:
+        """
+        Whether this runner is aware of all simulations (false)
+        or it has been triggered by a multithread runner and is thus
+        aware of a subset of all runs only (true).
+        """
+        return self.controlled_by_parent
+
+    def on_simulation_start(self, n_runs_total) -> None:
+        self.n_runs_total = n_runs_total
+        self._on_simulation_start()
+
+    @abstractmethod
+    def _on_simulation_start(self) -> None:
+        pass
+
+    def on_run_start(self, configuration, sim_uuid) -> None:
+        """
+        Args:
+            configuration (dict): dictionary representing the combination of parameters simulated in this specific
+            sim_uuid (str): unique identifier string for the simulation. This value is used to name the result folder,
+                            and it is referenced in the result JSON file.
+        """
+        self._on_run_start(configuration, sim_uuid)
+
+    @abstractmethod
+    def _on_run_start(self, configuration: dict, sim_uuid: str) -> None:
+        pass
+
+    @abstractmethod
+    def _on_run_end(self, sim_uuid: str, return_code: int, sim_time: int) -> bool:
+        """
+        :return: If the callback returns False, training is aborted early.
+        # TODO maybe it does not make a lot of sense since this will be eventually overridden by the callback user
+        """
+        return True
+
+    def on_run_end(self, sim_uuid: str, return_code: int, sim_time: int) -> bool:
+        """
+        This method will be called when each simulation run finishes
+        # TODO maybe it does not make a lot of sense since this will be eventually overridden by the callback user
+        :return: If the callback returns False, a run has failed.
+        """
+        self.n_runs_over += 1
+        self.run_sim_times.append(sim_time)
+        if return_code == 0:
+            self.n_runs_over_no_errors += 1  # type: int
+        else:
+            self.n_runs_over_errors += 1  # type: int
+
+        return self._on_run_end(sim_uuid, return_code, sim_time)
+
+    def on_simulation_end(self) -> None:
+        self._on_simulation_end()
+
+    @abstractmethod
+    def _on_simulation_end(self) -> None:
+        pass
 
 # def interactive_plot(campaign, param_ranges, result_parsing_function, x_axis,
 #                      runs=None):

--- a/sem/utils.py
+++ b/sem/utils.py
@@ -113,8 +113,7 @@ def get_command_from_result(script, path, result, debug=False):
         debug (bool): Whether the command should include the debugging
             template.
     """
-    command = "python3 "
-    command += "./ns3 run " if os.path.exists(os.path.join(path, "ns3")) else " ./waf --run "
+    command = "./ns3 run " if os.path.exists(os.path.join(path, "ns3")) else "python3 ./waf --run "
 
     if not debug:
         command += script + " " + " ".join(

--- a/sem/utils.py
+++ b/sem/utils.py
@@ -116,11 +116,11 @@ def get_command_from_result(script, path, result, debug=False):
     command = "./ns3 run " if os.path.exists(os.path.join(path, "ns3")) else "python3 ./waf --run "
 
     if not debug:
-        command += script + " " + " ".join(
+        command += "\"" + script + " " + " ".join(
             ['--%s=%s' % (param, value) for param, value in
              result['params'].items()]) + "\""
     else:
-        command += script + " --command-template=\"" +\
+        command += "\"" + script + " --command-template=\"" +\
             "gdb --args %s " + " ".join(['--%s=%s' % (param, value) for
                                          param, value in
                                          result['params'].items()]) + "\""

--- a/sem/utils.py
+++ b/sem/utils.py
@@ -1,4 +1,5 @@
 import io
+import os
 import math
 import copy
 import warnings
@@ -101,21 +102,26 @@ def list_param_combinations(param_ranges):
     return [param_ranges_copy]
 
 
-def get_command_from_result(script, result, debug=False):
+def get_command_from_result(script, path, result, debug=False):
     """
     Return the command that is needed to obtain a certain result.
 
     Args:
         params (dict): Dictionary containing parameter: value pairs.
+        path (str): The path to the ns-3 folder, used to discern which
+            build system (waf/CMake) is used
         debug (bool): Whether the command should include the debugging
             template.
     """
+    command = "python3 "
+    command += "./ns3 run " if os.path.exists(os.path.join(path, "ns3")) else " ./waf --run "
+
     if not debug:
-        command = "python3 waf --run \"" + script + " " + " ".join(
+        command += script + " " + " ".join(
             ['--%s=%s' % (param, value) for param, value in
              result['params'].items()]) + "\""
     else:
-        command = "python3 waf --run " + script + " --command-template=\"" +\
+        command += script + " --command-template=\"" +\
             "gdb --args %s " + " ".join(['--%s=%s' % (param, value) for
                                          param, value in
                                          result['params'].items()]) + "\""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,7 @@ def ns_3_compiled(tmpdir):
 
     # Relocate build by running the same command in the new directory
     if subprocess.call([build_program, 'configure', '--disable-gtk',
-                        '--build-profile=optimized', '--enable-modules=core',
+                        '--build-profile=optimized', '--enable-modules=core', '--enable-examples',
                         '--out=build/optimized'],
                        cwd=ns_3_tempdir,
                        stdout=subprocess.DEVNULL,
@@ -70,7 +70,7 @@ def ns_3_compiled_debug(tmpdir):
 
     # Relocate build by running the same command in the new directory
     if subprocess.call([build_program, 'configure', '--disable-gtk',
-                        '--build-profile=debug', '--enable-modules=core',
+                        '--build-profile=debug', '--enable-modules=core', '--enable-examples',
                         '--out=build'],
                        cwd=ns_3_tempdir,
                        stdout=subprocess.DEVNULL,
@@ -85,6 +85,26 @@ def ns_3_compiled_debug(tmpdir):
 
     return ns_3_tempdir
 
+@pytest.fixture(scope='function')
+def ns_3_compiled_examples():
+    # Configure and build WAF-based ns-3
+    build_program = get_build_program(ns_3_examples)
+
+    if subprocess.call([build_program, 'configure', '--disable-gtk',
+                        '--build-profile=optimized', '--enable-modules=core',
+                        '--out=build/optimized'],
+                       cwd=ns_3_examples,
+                       stdout=subprocess.DEVNULL,
+                       stderr=subprocess.STDOUT) != 0:
+        raise Exception("Examples configuration failed.")
+    
+    if subprocess.call([build_program, 'build'],
+                       cwd=ns_3_examples,
+                       stdout=subprocess.DEVNULL,
+                       stderr=subprocess.DEVNULL) > 0:
+        raise Exception("Examples build failed.")
+    
+    return ns_3_examples
 
 @pytest.fixture(scope='function')
 def config(tmpdir, ns_3_compiled):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,22 @@
-from sem import list_param_combinations, automatic_parser, stdout_automatic_parser, CallbackBase, CampaignManager
+from sem import list_param_combinations, automatic_parser, stdout_automatic_parser, get_command_from_result, CallbackBase, CampaignManager
 import json
 import numpy as np
+import pytest
 from operator import getitem
+
+
+@pytest.fixture(scope='function', params=[['compiled', False]])
+def ns_3_compiled_folder_and_command(ns_3_compiled, ns_3_compiled_examples, request):
+    if request.param[0] == 'compiled':
+        if request.param[1] is False:
+            return [ns_3_compiled, False, './ns3 run \"hash-example --dict=/usr/share/dict/american-english --time=False --RngRun=0\"']
+        # elif request.param[1] is True:
+        #     return [ns_3_compiled, True, './ns3 run \"hash-example --dict=/usr/share/dict/american-english --time=False --RngRun=0\"']
+    elif request.param[0] == 'compiled_examples':
+        if request.param[1] is False:
+            return [ns_3_compiled_examples, False, 'python3 ./waf --run \"hash-example --dict=/usr/share/dict/american-english --time=False --RngRun=0\"']
+        # elif request.param[1] is True:
+        #     return [ns_3_compiled_examples, True, 'python3 ./waf --run \"hash-example --dict=/usr/share/dict/american-english --time=False --RngRun=0\"']
 
 
 def test_list_param_combinations():
@@ -139,3 +154,31 @@ def test_callback(ns_3_compiled, config, parameter_combination):
     campaign.run_missing_simulations(
         param_list=[parameter_combination], callbacks=[cb])
     assert expected_output == cb.output
+@pytest.mark.parametrize('ns_3_compiled_folder_and_command',
+                         [
+                             ['compiled', False],
+                             ['compiled_examples', False]
+                         ],
+                         indirect=True)
+
+
+def test_get_cmnd_from_result(ns_3_compiled_folder_and_command, config, parameter_combination):
+
+    # Create an ns-3 campaign to run simulations and obtain a result
+    ns_3_folder = ns_3_compiled_folder_and_command[0]
+    hardcoded_command = ns_3_compiled_folder_and_command[2]
+
+    cmpgn = CampaignManager.new(ns_3_folder,
+                                config['script'],
+                                config['campaign_dir'],
+                                overwrite=True,
+                                skip_configuration=True)
+
+    cmpgn.run_simulations([parameter_combination], show_progress=False)
+
+    # Retrieve the results, and compare the output of get_command_from_result
+    # with the expected command
+    result = cmpgn.db.get_complete_results()[0]
+    cmnd = get_command_from_result(
+        config['script'], ns_3_folder, result)
+    assert (hardcoded_command == cmnd)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from sem import list_param_combinations, automatic_parser, stdout_automatic_parser
+from sem import list_param_combinations, automatic_parser, stdout_automatic_parser, CallbackBase, CampaignManager
 import json
 import numpy as np
 from operator import getitem
@@ -101,3 +101,41 @@ def test_automatic_parser(result):
                                        [6, 7, 8, 9, 10]])
     assert parsed['stderr'] == []
 
+
+class TestCallback(CallbackBase):
+
+    # Prevent pytest from trying to collect this function as a test
+    __test__ = False
+
+    def __init__(self):
+        CallbackBase.__init__(self, verbose=2)
+        self.output = ''
+
+    def _on_simulation_start(self) -> None:
+        self.output += 'Starting the simulations!\n'
+
+    def _on_simulation_end(self) -> None:
+        self.output += 'Simulations are over!\n'
+
+    def _on_run_start(self, configuration: dict, sim_uuid: str) -> None:
+        self.output += 'Start single run!\n'
+
+    def _on_run_end(self, sim_uuid: str, return_code: int, sim_time: int) -> bool:
+        self.output += f'Run ended! {return_code}\n'
+        return True
+
+
+def test_callback(ns_3_compiled, config, parameter_combination):
+    cb = TestCallback()
+    n_runs = 10
+    expected_output = 'Starting the simulations!\n' + \
+        f'Start single run!\nRun ended! {0}\n' * \
+        n_runs + 'Simulations are over!\n'
+
+    campaign = CampaignManager.new(ns_3_compiled, config['script'], config['campaign_dir'],
+                                   runner_type='SimulationRunner', overwrite=True)
+    parameter_combination.update({'RngRun': [
+        run for run in range(n_runs)]})
+    campaign.run_missing_simulations(
+        param_list=[parameter_combination], callbacks=[cb])
+    assert expected_output == cb.output


### PR DESCRIPTION
This PR:

- Updates get_command_from_result to support both CMake and Waf versions of ns-3
- Adds a test for `get_command_from_result`
- Adds test cases for checking the runner for Waf-based versions of ns-3