### PR TITLE
Use long-term averages for runner simulation ETAs

### DIFF
--- a/sem/manager.py
+++ b/sem/manager.py
@@ -350,6 +350,7 @@ class CampaignManager(object):
         if show_progress:
             result_generator = tqdm(results, total=len(param_list),
                                     unit='simulation',
+                                    smoothing=0,
                                     desc='Running simulations')
         else:
             result_generator = results


### PR DESCRIPTION
Before this PR, the simulations ETA was computed using a moving average, which provided poor estimates when used in conjunction with multi-process runners.
Therefore, this PR switches to purely long-term averages for estimating the time remaining for simulations.