### PR TITLE
Update CI, support Python 3.12

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,17 +14,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
         
     - name: Install GCC
       uses: egor-tensin/setup-gcc@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Poetry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ pandas = "*"
 click = "*"
 salib = "^1.3.8"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 sphinx = "*"
 pylint = "*"
 sphinxcontrib-napoleon = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,15 @@ homepage = "https://github.com/signetlabdei/sem"
 keywords = ["ns-3", "simulation", "execution"]
 
 [tool.poetry.dependencies]
-python = ">3.8,<4"
+python = ">=3.9,<4"
 tqdm = "*"
 gitpython = "*"
 drmaa = "*"
 tinydb = "^4.0.0"
 xarray = "*"
-numpy = "^1.21.5"
+# Numpy 1.26.0 is needed to support Python >=3.12, which dropped distutils. 
+# See https://github.com/python-poetry/poetry/issues/7611#issuecomment-1793859449 
+numpy = "^1.26.0" 
 pandas = "*"
 click = "*"
 salib = "^1.3.8"


### PR DESCRIPTION
- Bump CI actions to avoid deprecation warnings
- Drop Python 3.8 and add Python 3.12 to CI test matrix
- Bump Numpy version to >=1.26.0 to support drop of distutils in Python 3.12