### PR TITLE
Fix parallel parsing of many files in get_results_as_dataframe

### DIFF
--- a/sem/manager.py
+++ b/sem/manager.py
@@ -587,11 +587,11 @@ class CampaignManager(object):
         if parallel_parsing:
             with Pool(processes=self.runner.max_parallel_processes) as pool:
                 for parsed_result in tqdm(pool.imap_unordered(parse_result,
-                                                              [[self.db.get_complete_results(result_id=result['meta']['id'],
+                                                              ([self.db.get_complete_results(result_id=result['meta']['id'],
                                                                                              files_to_load=files_to_load)[0],
                                                                 function_yields_multiple_results,
                                                                 result_parsing_function,
-                                                                param_columns] for result in results_list]),
+                                                                param_columns] for result in results_list)),
                                           total=len(results_list),
                                           unit='result',
                                           desc='Parsing Results',


### PR DESCRIPTION
Hello,

When working with 1000+ simulation result files, the `parallel_parsing` option of the `CampaignManager.get_results_as_dataframe()` utility causes the main process to get stuck trying to open and load all the files at once, with no display of progress. If the files are big, this could eventually lead to memory issues and crashes.

This happens because the program is trying to build at once the full list of inputs to be fed to `pool.imap_unordered`.  As a simple fix, I suggest to change the list into a generator. Generators are lazy iterators, so each file is only opened when the next element is requested by `pool.imap_unordered`, and closed when the task is done. As an added benefit, this also fixes the `tqdm` progress bar, which otherwise appears only when the list is completely loaded.

Best,
Alessandro